### PR TITLE
feat: prise en charge des ojects invoquable plutot que des closures niquement

### DIFF
--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -38,7 +38,7 @@ class Scheduler
     /**
      * Planifie l'execution d'une closure.
      */
-    public function call(Closure $func): Task
+    public function call(callable $func): Task
     {
         return $this->createTask('closure', $func);
     }

--- a/src/Task.php
+++ b/src/Task.php
@@ -231,7 +231,7 @@ class Task
      */
     protected function runClosure(): mixed
     {
-        return $this->getAction()->__invoke();
+        return service('container')->call($this->getAction());
     }
 
     /**


### PR DESCRIPTION
<!--

Chaque pull request doit traiter d’un seul problème et avoir un titre significatif.

- Les pull request doivent être en français.
- Si une pull request résout un problème, référencez le problème avec un mot-clé approprié (par exemple, fix <numéro de problème>).
- Toutes les corrections de bugs doivent être envoyées à la branche __"dev"__, c'est là que la prochaine version de correction de bug sera développée.
- Les PR avec toute amélioration doivent être envoyés à la branche de version mineure suivante, par ex. __"1.2"__

-->
**Description**
Avant, seules les closures pouvaient être définies dans la méthode `$schedule->call()`. Cette PR autorise tout éléments de type callable à être pris en compte.

Par ailleurs, ces callables sont désormais lancé via le container, ce qui permet l'injection de dépendances à ce niveau

**Liste de contrôle:**
- [ ] Des commits signés en toute sécurité
- [ ] Composant(s) avec blocs PHPDoc, uniquement si nécessaire ou ajoute de la valeur
- [x] Tests unitaires, avec une couverture > 80 %
- [ ] Guide de l'utilisateur mis à jour
- [x] Conforme au guide de style
